### PR TITLE
Add timezone support for dates package

### DIFF
--- a/configuration/jest/global-setup.js
+++ b/configuration/jest/global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = "America/New_York"; // -05:00 (STD) or -04:00 (DST)
+};

--- a/docs/pages/dates/dates-provider.mdx
+++ b/docs/pages/dates/dates-provider.mdx
@@ -12,6 +12,36 @@ components exported from `@mantine/dates` package. `DatesProvider` supports the 
 - `locale` – dayjs locale, note that you also need to import corresponding locale module from dayjs. Default value is `en`.
 - `firstDayOfWeek` – number from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is 1 – Monday.
 - `weekendDays` – an array of numbers from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is `[0, 6]` – Saturday and Sunday.
-- `timezone` – a string providing the timezone. i.e. `UTC`
+- `timezone` – a textual representation of a time zone, for example, `UTC`.
 
 <Demo data={DatesProviderDemos.usage} />
+
+## Timezone
+
+When working with the `DatesProvider`, parsing the `timezone` parameter offers a valuable feature for controlling how
+dates and times are displayed within your application. By specifying a timezone of your choice, you can ensure
+that date information is presented in the desired timezone, rather than relying on the user's browser settings.
+If you don't provide a `timezone` parameter or explicitly set it to `undefined`, the application will default to using
+the user's browser timezone.
+
+The `timezone` parameter sets the timezone context for all components integrated within the `DatesProvider`. This means
+that all date and time-related data displayed within your application will adhere to the specified timezone. This simplifies
+the process of maintaining consistency in how dates and times are presented to users across various parts of your application.
+
+### Accessing the Timezone Information
+
+If you need to access the current timezone information from other parts of your application, you can leverage the
+`getTimezone()` function provided by the `useDatesContext()` hook. This function allows you to retrieve the active
+timezone setting and use it as needed.
+
+### Date Format Considerations
+
+It's important to note that the `DatesProvider` system supports the provision of dates in the user's local timezone.
+However, many backend systems and data sources use Coordinated Universal Time (UTC) timestamps. In such cases, you can
+easily convert and parse UTC timestamps into the user's timezone using JavaScript, as demonstrated by
+the example: `new Date('2000-10-03 02:10:00Z')`.
+
+By effectively utilizing the `timezone` parameter and the provided functions, you can tailor the presentation of date
+and time data to meet the specific requirements of your application while maintaining compatibility with various data sources.
+
+<Demo data={DatesProviderDemos.timezone} />

--- a/docs/pages/dates/dates-provider.mdx
+++ b/docs/pages/dates/dates-provider.mdx
@@ -12,5 +12,6 @@ components exported from `@mantine/dates` package. `DatesProvider` supports the 
 - `locale` – dayjs locale, note that you also need to import corresponding locale module from dayjs. Default value is `en`.
 - `firstDayOfWeek` – number from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is 1 – Monday.
 - `weekendDays` – an array of numbers from 0 to 6, where 0 is Sunday and 6 is Saturday. Default value is `[0, 6]` – Saturday and Sunday.
+- `timezone` – a string providing the timezone. i.e. `UTC`
 
 <Demo data={DatesProviderDemos.usage} />

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   setupFilesAfterEnv: ['./configuration/jest/jsdom.mocks.js'],
+  globalSetup: "./configuration/jest/global-setup.js",
   moduleNameMapper: {
     '@mantine/(.*)': '<rootDir>/src/mantine-$1/src',
     '\\.(css)$': 'identity-obj-proxy',

--- a/src/mantine-dates/src/components/Calendar/Calendar.tsx
+++ b/src/mantine-dates/src/components/Calendar/Calendar.tsx
@@ -19,6 +19,9 @@ import { clampLevel } from './clamp-level/clamp-level';
 import { MonthLevelSettings } from '../MonthLevel';
 import { YearLevelSettings } from '../YearLevel';
 import { DecadeLevelSettings } from '../DecadeLevel';
+import { useDatesContext } from '../DatesProvider';
+import { shiftTimezone } from '../../utils';
+import { useUncontrolledDates } from '../../hooks';
 
 export type CalendarStylesNames =
   | MonthLevelGroupStylesNames
@@ -76,6 +79,9 @@ export interface CalendarSettings
 
 export interface CalendarBaseProps {
   __staticSelector?: string;
+
+  /** Internal Variable to check if timezones were applied by parent component */
+  __timezoneApplied?: boolean;
 
   /** Prevents focus shift when buttons are clicked */
   __preventFocus?: boolean;
@@ -219,6 +225,7 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     onNextMonth,
     onPreviousMonth,
     static: isStatic,
+    __timezoneApplied,
     ...others
   } = props;
 
@@ -235,11 +242,12 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     onChange: onLevelChange,
   });
 
-  const [_date, setDate] = useUncontrolled({
+  const [_date, setDate] = useUncontrolledDates({
+    type: 'default',
     value: date,
     defaultValue: defaultDate,
-    finalValue: null,
-    onChange: onDateChange,
+    onChange: onDateChange as any,
+    applyTimezone: !__timezoneApplied,
   });
 
   const stylesApiProps = {
@@ -250,8 +258,10 @@ export const Calendar = factory<CalendarFactory>((_props, ref) => {
     size,
   };
 
+  const ctx = useDatesContext();
+
   const _columnsToScroll = columnsToScroll || numberOfColumns || 1;
-  const currentDate = _date || new Date();
+  const currentDate = _date || shiftTimezone('add', new Date(), ctx.getTimezone());
 
   const handleNextMonth = () => {
     const nextDate = dayjs(currentDate).add(_columnsToScroll, 'month').toDate();

--- a/src/mantine-dates/src/components/DateInput/DateInput.test.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.test.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mantine/dates-tests';
 import { __InputStylesNames } from '@mantine/core';
 import { DateInput, DateInputProps } from './DateInput';
+import { DatesProvider } from '../DatesProvider';
 
 const defaultProps: DateInputProps = {
   popoverProps: { transitionProps: { duration: 0 }, withinPortal: false },
@@ -148,6 +149,17 @@ describe('@mantine/dates/DateInput', () => {
     expectValue(container, 'April 1, 2022');
   });
 
+  it('supports uncontrolled state (dropdown click) with timezone', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DateInput date={new Date(2022, 0, 31, 23)} {...defaultProps} />
+      </DatesProvider>
+    );
+    await userEvent.tab();
+    await clickControl(container, 4);
+    expectValue(container, 'February 4, 2022');
+  });
+
   it('supports controlled state (dropdown click)', async () => {
     const spy = jest.fn();
     const { container } = render(
@@ -162,6 +174,24 @@ describe('@mantine/dates/DateInput', () => {
     await clickControl(container, 4);
     expectValue(container, 'April 11, 2022');
     expect(spy).toHaveBeenCalledWith(new Date(2022, 3, 1));
+  });
+
+  it('supports controlled state (dropdown click) with timezone', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DateInput
+          {...defaultProps}
+          date={new Date(2022, 0, 31, 23)}
+          value={new Date(2022, 0, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+    await userEvent.tab();
+    await clickControl(container, 4);
+    expectValue(container, 'February 1, 2022');
+    expect(spy).toHaveBeenCalledWith(new Date(2022, 1, 3, 23));
   });
 
   it('supports uncontrolled state (free input)', async () => {
@@ -183,6 +213,21 @@ describe('@mantine/dates/DateInput', () => {
     await userEvent.tab();
     expectValue(container, 'April 11, 2022');
     expect(spy).toHaveBeenLastCalledWith(new Date(2022, 3, 1));
+  });
+
+  it('supports controlled state (free input) with timezone', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DateInput {...defaultProps} value={new Date(2022, 3, 11)} onChange={spy} />
+      </DatesProvider>
+    );
+    await userEvent.tab();
+    await userEvent.clear(getInput(container));
+    await userEvent.type(getInput(container), 'April 1, 2022');
+    await userEvent.tab();
+    expectValue(container, 'April 11, 2022');
+    expect(spy).toHaveBeenLastCalledWith(new Date(2022, 2, 31, 20));
   });
 
   it('clears input when clear button is clicked (uncontrolled)', async () => {

--- a/src/mantine-dates/src/components/DateInput/DateInput.tsx
+++ b/src/mantine-dates/src/components/DateInput/DateInput.tsx
@@ -15,7 +15,7 @@ import {
   CloseButton,
   MantineSize,
 } from '@mantine/core';
-import { useUncontrolled, useDidUpdate } from '@mantine/hooks';
+import { useDidUpdate } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import { Calendar, CalendarBaseProps, CalendarStylesNames, pickCalendarProps } from '../Calendar';
 import { DecadeLevelSettings } from '../DecadeLevel';
@@ -27,6 +27,7 @@ import { DateValue, CalendarLevel } from '../../types';
 import { useDatesContext } from '../DatesProvider';
 import { isDateValid } from './is-date-valid/is-date-valid';
 import { dateStringParser } from './date-string-parser/date-string-parser';
+import { useUncontrolledDates } from '../../hooks';
 
 export type DateInputStylesNames = __InputStylesNames | CalendarStylesNames;
 
@@ -139,7 +140,9 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
   const ctx = useDatesContext();
   const defaultDateParser = (val: string) => {
     const parsedDate = dayjs(val, valueFormat, ctx.getLocale(locale)).toDate();
-    return Number.isNaN(parsedDate.getTime()) ? dateStringParser(val) : parsedDate;
+    return Number.isNaN(parsedDate.getTime())
+      ? dateStringParser(val, ctx.getTimezone())
+      : parsedDate;
   };
 
   const _dateParser = dateParser || defaultDateParser;
@@ -148,18 +151,18 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
   const formatValue = (val: Date) =>
     val ? dayjs(val).locale(ctx.getLocale(locale)).format(valueFormat) : '';
 
-  const [_value, setValue, controlled] = useUncontrolled({
+  const [_value, setValue, controlled] = useUncontrolledDates({
+    type: 'default',
     value,
     defaultValue,
-    finalValue: null,
     onChange,
   });
 
-  const [_date, setDate] = useUncontrolled({
+  const [_date, setDate] = useUncontrolledDates({
+    type: 'default',
     value: date,
     defaultValue: defaultValue || defaultDate,
-    finalValue: null,
-    onChange: onDateChange,
+    onChange: onDateChange as any,
   });
 
   useEffect(() => {
@@ -278,6 +281,7 @@ export const DateInput = factory<DateInputFactory>((_props, ref) => {
           <Popover.Dropdown onMouseDown={(event) => event.preventDefault()} data-dates-dropdown>
             <Calendar
               __staticSelector="DateInput"
+              __timezoneApplied
               {...calendarProps}
               classNames={classNames}
               styles={styles}

--- a/src/mantine-dates/src/components/DateInput/date-string-parser/date-string-parser.ts
+++ b/src/mantine-dates/src/components/DateInput/date-string-parser/date-string-parser.ts
@@ -1,9 +1,11 @@
-export function dateStringParser(dateString: string | null) {
+import { shiftTimezone } from '../../../utils';
+
+export function dateStringParser(dateString: string | null, timezone?: string) {
   if (dateString === null) {
     return null;
   }
 
-  const date = new Date(dateString);
+  const date = shiftTimezone('add', new Date(dateString), timezone);
 
   if (Number.isNaN(date.getTime()) || !dateString) {
     return null;

--- a/src/mantine-dates/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/mantine-dates/src/components/DatePicker/DatePicker.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, tests, userEvent } from '@mantine/tests';
 import { datesTests } from '@mantine/dates-tests';
 import { DatePicker, DatePickerProps, DatePickerStylesNames } from './DatePicker';
+import { DatesProvider } from '../DatesProvider';
 
 const defaultProps = {
   defaultDate: new Date(2022, 3, 11),
@@ -76,6 +77,44 @@ describe('@mantine/dates/DatePicker', () => {
     expect(spy).toHaveBeenCalledWith(new Date(2022, 2, 28));
   });
 
+  it('can be controlled (type="default") with timezone (UTC)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DatePicker
+          {...defaultProps}
+          date={new Date(2022, 0, 31, 23)}
+          value={new Date(2022, 0, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('1');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2022, 0, 30, 19));
+  });
+
+  it('can be controlled (type="default") with timezone (America/Los_Angeles)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'America/Los_Angeles' }}>
+        <DatePicker
+          {...defaultProps}
+          date={new Date(2022, 0, 31, 23)}
+          value={new Date(2022, 0, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('31');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2021, 11, 27, 3));
+  });
+
   it('can be uncontrolled (type="multiple")', async () => {
     const { container } = render(
       <DatePicker {...defaultProps} type="multiple" date={new Date(2022, 3, 11)} />
@@ -106,6 +145,24 @@ describe('@mantine/dates/DatePicker', () => {
 
     await userEvent.click(container.querySelector('table button')!);
     expect(spy).toHaveBeenCalledWith([new Date(2022, 3, 11), new Date(2022, 2, 28)]);
+  });
+
+  it('can be controlled (type="multiple") with timezone', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DatePicker
+          {...defaultProps}
+          type="multiple"
+          date={new Date(2022, 0, 31, 23)}
+          value={[new Date(2022, 0, 31, 23)]}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith([new Date(2022, 0, 31, 23), new Date(2022, 0, 30, 19)]);
   });
 
   it('can be uncontrolled (type="range")', async () => {

--- a/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
+++ b/src/mantine-dates/src/components/DatePicker/DatePicker.tsx
@@ -15,6 +15,8 @@ import { Calendar, CalendarBaseProps, CalendarSettings, CalendarStylesNames } fr
 import { DecadeLevelBaseSettings } from '../DecadeLevel';
 import { YearLevelBaseSettings } from '../YearLevel';
 import { MonthLevelBaseSettings } from '../MonthLevel';
+import { shiftTimezone } from '../../utils';
+import { useDatesContext } from '../DatesProvider';
 
 export type DatePickerStylesNames = CalendarStylesNames;
 
@@ -79,6 +81,7 @@ export const DatePicker: DatePickerComponent = factory<DatePickerFactory>((_prop
     hideOutsideDates,
     __onDayMouseEnter,
     __onDayClick,
+    __timezoneApplied,
     ...others
   } = props;
 
@@ -91,6 +94,7 @@ export const DatePicker: DatePickerComponent = factory<DatePickerFactory>((_prop
     defaultValue,
     onChange,
     onMouseLeave,
+    applyTimezone: !__timezoneApplied,
   });
 
   const { resolvedClassNames, resolvedStyles } = useResolvedStylesApi<DatePickerFactory>({
@@ -98,6 +102,7 @@ export const DatePicker: DatePickerComponent = factory<DatePickerFactory>((_prop
     styles,
     props,
   });
+  const ctx = useDatesContext();
 
   return (
     <Calendar
@@ -122,6 +127,8 @@ export const DatePicker: DatePickerComponent = factory<DatePickerFactory>((_prop
         ...getDayProps?.(date),
       })}
       {...others}
+      date={shiftTimezone('add', others.date, ctx.getTimezone(), __timezoneApplied)}
+      __timezoneApplied
     />
   );
 }) as any;

--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.test.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { tests, inputDefaultProps, inputStylesApiSelectors, render } from '@mantine/tests';
 import { __InputStylesNames } from '@mantine/core';
-import { datesTests, expectValue } from '@mantine/dates-tests';
+import { clickControl, clickInput, datesTests, expectValue } from '@mantine/dates-tests';
 import { DatePickerInput, DatePickerInputProps } from './DatePickerInput';
+import { DatesProvider } from '../DatesProvider';
 
 const defaultProps = {
   popoverProps: { withinPortal: false, transitionProps: { duration: 0 } },
@@ -105,5 +106,34 @@ describe('@mantine/dates/DatePickerInput', () => {
     );
 
     expect(container.querySelector('table button')).toHaveClass('mantine-DatePickerInput-day');
+  });
+
+  it('supports controlled state (dropdown click)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatePickerInput {...defaultProps} value={new Date(2022, 3, 11)} onChange={spy} />
+    );
+    await clickInput(container);
+    await clickControl(container, 4);
+    expectValue(container, 'April 11, 2022');
+    expect(spy).toHaveBeenCalledWith(new Date(2022, 3, 1));
+  });
+
+  it('supports controlled state (dropdown click) with timezone', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DatePickerInput
+          {...defaultProps}
+          date={new Date(2022, 0, 31, 23)}
+          value={new Date(2022, 0, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+    await clickInput(container);
+    await clickControl(container, 4);
+    expectValue(container, 'February 1, 2022');
+    expect(spy).toHaveBeenCalledWith(new Date(2022, 1, 3, 19));
   });
 });

--- a/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
+++ b/src/mantine-dates/src/components/DatePickerInput/DatePickerInput.tsx
@@ -14,8 +14,9 @@ import { CalendarStylesNames, pickCalendarProps } from '../Calendar';
 import { useDatesInput } from '../../hooks';
 import { DatePicker, DatePickerBaseProps } from '../DatePicker';
 import { DatePickerType } from '../../types';
-import { getDefaultClampedDate } from '../../utils';
+import { getDefaultClampedDate, shiftTimezone } from '../../utils';
 import { PickerInputBase, DateInputSharedProps } from '../PickerInputBase';
+import { useDatesContext } from '../DatesProvider';
 
 export type DatePickerInputStylesNames = __InputStylesNames | CalendarStylesNames;
 
@@ -105,6 +106,7 @@ export const DatePickerInput: DatePickerInputComponent = factory<DatePickerInput
     });
 
     const _defaultDate = Array.isArray(_value) ? _value[0] || defaultDate : _value || defaultDate;
+    const ctx = useDatesContext();
 
     return (
       <PickerInputBase
@@ -131,7 +133,9 @@ export const DatePickerInput: DatePickerInputComponent = factory<DatePickerInput
           variant={variant}
           type={type}
           value={_value}
-          defaultDate={_defaultDate || getDefaultClampedDate({ maxDate, minDate })}
+          defaultDate={
+            _defaultDate || getDefaultClampedDate({ maxDate, minDate, timezone: ctx.getTimezone() })
+          }
           onChange={setValue}
           locale={locale}
           classNames={resolvedClassNames}
@@ -141,6 +145,8 @@ export const DatePickerInput: DatePickerInputComponent = factory<DatePickerInput
           __stopPropagation={dropdownType === 'popover'}
           minDate={minDate}
           maxDate={maxDate}
+          date={shiftTimezone('add', calendarProps.date, ctx.getTimezone())}
+          __timezoneApplied
         />
       </PickerInputBase>
     );

--- a/src/mantine-dates/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/src/mantine-dates/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -181,6 +181,23 @@ describe('@mantine/dates/DateTimePicker', () => {
     expectValue(container, '03/04/2022 14:45');
   });
 
+  it('supports uncontrolled state with timezone', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DateTimePicker {...defaultProps} defaultValue={new Date(2022, 0, 31, 23)} />
+      </DatesProvider>
+    );
+    expectValue(container, '01/02/2022 04:00');
+
+    await clickInput(container);
+    await userEvent.click(container.querySelectorAll('table button')[6]);
+    expectValue(container, '06/02/2022 04:00');
+
+    await userEvent.clear(getTimeInput());
+    await userEvent.type(getTimeInput(), '14:45');
+    expectValue(container, '06/02/2022 14:45');
+  });
+
   it('supports controlled state', async () => {
     const spy = jest.fn();
 
@@ -192,6 +209,22 @@ describe('@mantine/dates/DateTimePicker', () => {
     await userEvent.click(container.querySelectorAll('table button')[6]);
     expectValue(container, '11/04/2022 00:00');
     expect(spy).toHaveBeenLastCalledWith(new Date(2022, 3, 3));
+  });
+
+  it('supports controlled state with timezone', async () => {
+    const spy = jest.fn();
+
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <DateTimePicker {...defaultProps} value={new Date(2022, 0, 31, 23)} onChange={spy} />
+      </DatesProvider>
+    );
+    expectValue(container, '01/02/2022 04:00');
+
+    await clickInput(container);
+    await userEvent.click(container.querySelectorAll('table button')[6]);
+    expectValue(container, '01/02/2022 04:00');
+    expect(spy).toHaveBeenLastCalledWith(new Date(2022, 1, 5, 23));
   });
 
   it('displays correct value when withSeconds is set', () => {

--- a/src/mantine-dates/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/src/mantine-dates/src/components/DateTimePicker/DateTimePicker.tsx
@@ -13,8 +13,8 @@ import {
   ActionIcon,
   CheckIcon,
 } from '@mantine/core';
-import { useDisclosure, useUncontrolled, useDidUpdate, useMergedRef } from '@mantine/hooks';
-import { assignTime } from '../../utils';
+import { useDisclosure, useDidUpdate, useMergedRef } from '@mantine/hooks';
+import { assignTime, shiftTimezone } from '../../utils';
 import { TimeInput, TimeInputProps } from '../TimeInput';
 import {
   pickCalendarProps,
@@ -31,6 +31,7 @@ import {
 import { DateValue } from '../../types';
 import { useDatesContext } from '../DatesProvider';
 import classes from './DateTimePicker.module.css';
+import { useUncontrolledDates } from '../../hooks';
 
 export type DateTimePickerStylesNames =
   | 'timeWrapper'
@@ -129,10 +130,10 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
   } = pickCalendarProps(rest);
 
   const ctx = useDatesContext();
-  const [_value, setValue] = useUncontrolled({
+  const [_value, setValue] = useUncontrolledDates({
+    type: 'default',
     value,
     defaultValue,
-    finalValue: null,
     onChange,
   });
 
@@ -154,11 +155,11 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
 
     if (val) {
       const [hours, minutes, seconds] = val.split(':').map(Number);
-      const timeDate = new Date();
+      const timeDate = shiftTimezone('add', new Date(), ctx.getTimezone());
       timeDate.setHours(hours);
       timeDate.setMinutes(minutes);
       seconds !== undefined && timeDate.setSeconds(seconds);
-      setValue(assignTime(timeDate, _value || new Date()));
+      setValue(assignTime(timeDate, _value || shiftTimezone('add', new Date(), ctx.getTimezone())));
     }
   };
 
@@ -229,6 +230,7 @@ export const DateTimePicker = factory<DateTimePickerFactory>((_props, ref) => {
           setCurrentLevel(_level);
           calendarProps.onLevelChange?.(_level);
         }}
+        __timezoneApplied
       />
 
       {currentLevel === 'month' && (

--- a/src/mantine-dates/src/components/DatesProvider/DatesProvider.tsx
+++ b/src/mantine-dates/src/components/DatesProvider/DatesProvider.tsx
@@ -3,6 +3,7 @@ import { DayOfWeek } from '../../types';
 
 export interface DatesProviderValue {
   locale: string;
+  timezone: string | null;
   firstDayOfWeek: DayOfWeek;
   weekendDays: DayOfWeek[];
   labelSeparator: string;
@@ -12,6 +13,7 @@ export type DatesProviderSettings = Partial<DatesProviderValue>;
 
 export const DATES_PROVIDER_DEFAULT_SETTINGS: DatesProviderValue = {
   locale: 'en',
+  timezone: null,
   firstDayOfWeek: 1,
   weekendDays: [0, 6],
   labelSeparator: '–',

--- a/src/mantine-dates/src/components/DatesProvider/use-dates-context.test.tsx
+++ b/src/mantine-dates/src/components/DatesProvider/use-dates-context.test.tsx
@@ -13,6 +13,8 @@ describe('@mantine/dates/use-dates-context', () => {
     expect(hook.result.current.getLocale()).toBe('en');
     expect(hook.result.current.getLocale('ru')).toBe('ru');
 
+    expect(hook.result.current.getTimezone()).toBe(undefined);
+
     expect(hook.result.current.getFirstDayOfWeek()).toBe(1);
     expect(hook.result.current.getFirstDayOfWeek(0)).toBe(0);
     expect(hook.result.current.getFirstDayOfWeek(6)).toBe(6);
@@ -24,7 +26,9 @@ describe('@mantine/dates/use-dates-context', () => {
   it('returns correct values from DatesProvider context', () => {
     const hook = renderHook(() => useDatesContext(), {
       wrapper: ({ children }) => (
-        <DatesProvider settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [1, 2] }}>
+        <DatesProvider
+          settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [1, 2], timezone: 'UTC' }}
+        >
           {children}
         </DatesProvider>
       ),
@@ -36,6 +40,8 @@ describe('@mantine/dates/use-dates-context', () => {
 
     expect(hook.result.current.getLocale()).toBe('ru');
     expect(hook.result.current.getLocale('en')).toBe('en');
+
+    expect(hook.result.current.getTimezone()).toBe('UTC');
 
     expect(hook.result.current.getFirstDayOfWeek()).toBe(0);
     expect(hook.result.current.getFirstDayOfWeek(1)).toBe(1);

--- a/src/mantine-dates/src/components/DatesProvider/use-dates-context.ts
+++ b/src/mantine-dates/src/components/DatesProvider/use-dates-context.ts
@@ -5,6 +5,12 @@ import { DatesProviderContext } from './DatesProvider';
 export function useDatesContext() {
   const ctx = useContext(DatesProviderContext);
   const getLocale = useCallback((input?: string) => input || ctx.locale, [ctx.locale]);
+
+  const getTimezone = useCallback(
+    (input?: string) => input || ctx.timezone || undefined,
+    [ctx.timezone]
+  );
+
   const getFirstDayOfWeek = useCallback(
     (input?: DayOfWeek) => (typeof input === 'number' ? input : ctx.firstDayOfWeek),
     [ctx.firstDayOfWeek]
@@ -23,6 +29,7 @@ export function useDatesContext() {
   return {
     ...ctx,
     getLocale,
+    getTimezone,
     getFirstDayOfWeek,
     getWeekendDays,
     getLabelSeparator,

--- a/src/mantine-dates/src/components/Day/Day.tsx
+++ b/src/mantine-dates/src/components/Day/Day.tsx
@@ -14,6 +14,8 @@ import {
   getSize,
 } from '@mantine/core';
 import classes from './Day.module.css';
+import { shiftTimezone } from '../../utils';
+import { useDatesContext } from '../DatesProvider';
 
 export type DayStylesNames = 'day';
 export type DayCssVariables = {
@@ -110,13 +112,17 @@ export const Day = factory<DayFactory>((_props, ref) => {
     rootSelector: 'day',
   });
 
+  const ctx = useDatesContext();
+
   return (
     <UnstyledButton<any>
       {...getStyles('day')}
       component={isStatic ? 'div' : 'button'}
       ref={ref}
       disabled={disabled}
-      data-today={dayjs(date).isSame(new Date(), 'day') || undefined}
+      data-today={
+        dayjs(date).isSame(shiftTimezone('add', new Date(), ctx.getTimezone()), 'day') || undefined
+      }
       data-hidden={hidden || undefined}
       data-disabled={disabled || undefined}
       data-weekend={(!disabled && !outside && weekend) || undefined}

--- a/src/mantine-dates/src/components/Month/get-month-days/get-month-days.ts
+++ b/src/mantine-dates/src/components/Month/get-month-days/get-month-days.ts
@@ -1,11 +1,24 @@
 import { DayOfWeek } from '../../../types';
 import { getStartOfWeek } from '../get-start-of-week/get-start-of-week';
 import { getEndOfWeek } from '../get-end-of-week/get-end-of-week';
+import { shiftTimezone } from '../../../utils';
 
-export function getMonthDays(month: Date, firstDayOfWeek: DayOfWeek = 1): Date[][] {
+export function getMonthDays(
+  month: Date,
+  firstDayOfWeek: DayOfWeek = 1,
+  timezone: string | undefined = undefined
+): Date[][] {
   const currentMonth = month.getMonth();
-  const startOfMonth = new Date(month.getFullYear(), currentMonth, 1);
-  const endOfMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0);
+  const startOfMonth = shiftTimezone(
+    'add',
+    new Date(month.getFullYear(), currentMonth, 1),
+    timezone
+  );
+  const endOfMonth = shiftTimezone(
+    'add',
+    new Date(month.getFullYear(), month.getMonth() + 1, 0),
+    timezone
+  );
   const endDate = getEndOfWeek(endOfMonth, firstDayOfWeek);
   const date = getStartOfWeek(startOfMonth, firstDayOfWeek);
   const weeks: Date[][] = [];

--- a/src/mantine-dates/src/components/MonthPicker/MonthPicker.test.tsx
+++ b/src/mantine-dates/src/components/MonthPicker/MonthPicker.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, tests, userEvent } from '@mantine/tests';
 import { datesTests } from '@mantine/dates-tests';
 import { MonthPicker, MonthPickerProps, MonthPickerStylesNames } from './MonthPicker';
+import { DatesProvider } from '../DatesProvider';
 
 const defaultProps = {
   defaultDate: new Date(2022, 3, 11),
@@ -54,6 +55,17 @@ describe('@mantine/dates/MonthPicker', () => {
     expect(container.querySelector('[data-selected]')!.textContent).toBe('Jan');
   });
 
+  it('can be uncontrolled (type="default") with timezone', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <MonthPicker {...defaultProps} date={new Date(2022, 0, 31, 23)} />
+      </DatesProvider>
+    );
+    expect(container.querySelector('[data-selected]')!).toBe(null);
+    await userEvent.click(container.querySelector('table button')!);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('Jan');
+  });
+
   it('can be controlled (type="default")', async () => {
     const spy = jest.fn();
     const { container } = render(
@@ -71,9 +83,46 @@ describe('@mantine/dates/MonthPicker', () => {
     expect(spy).toHaveBeenCalledWith(new Date(2022, 0, 1));
   });
 
+  it('can be controlled (type="default") with timezone', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <MonthPicker
+          {...defaultProps}
+          date={new Date(2022, 0, 31, 23)}
+          value={new Date(2022, 0, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('Feb');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2021, 11, 31, 19));
+  });
+
   it('can be uncontrolled (type="multiple")', async () => {
     const { container } = render(
       <MonthPicker {...defaultProps} type="multiple" date={new Date(2022, 3, 11)} />
+    );
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(0);
+    await userEvent.click(container.querySelectorAll('table button')[0]);
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(1);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('Jan');
+
+    await userEvent.click(container.querySelectorAll('table button')[1]);
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(2);
+    expect(
+      Array.from(container.querySelectorAll('[data-selected]')).map((node) => node.textContent)
+    ).toStrictEqual(['Jan', 'Feb']);
+  });
+
+  it('can be uncontrolled (type="multiple") with timezone', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <MonthPicker {...defaultProps} type="multiple" date={new Date(2022, 0, 31, 23)} />
+      </DatesProvider>
     );
     expect(container.querySelectorAll('[data-selected]')).toHaveLength(0);
     await userEvent.click(container.querySelectorAll('table button')[0]);
@@ -101,6 +150,24 @@ describe('@mantine/dates/MonthPicker', () => {
 
     await userEvent.click(container.querySelector('table button')!);
     expect(spy).toHaveBeenCalledWith([new Date(2022, 3, 11), new Date(2022, 0, 1)]);
+  });
+
+  it('can be controlled (type="multiple") with timezone', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <MonthPicker
+          {...defaultProps}
+          type="multiple"
+          date={new Date(2022, 0, 31, 23)}
+          value={[new Date(2022, 0, 31, 23)]}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith([new Date(2022, 0, 31, 23), new Date(2021, 11, 31, 19)]);
   });
 
   it('can be uncontrolled (type="range")', async () => {

--- a/src/mantine-dates/src/components/MonthPicker/MonthPicker.tsx
+++ b/src/mantine-dates/src/components/MonthPicker/MonthPicker.tsx
@@ -16,6 +16,8 @@ import { PickerBaseProps, DatePickerType, CalendarLevel } from '../../types';
 import { Calendar, CalendarBaseProps } from '../Calendar';
 import { DecadeLevelGroupStylesNames } from '../DecadeLevelGroup';
 import { YearLevelGroupStylesNames } from '../YearLevelGroup';
+import { shiftTimezone } from '../../utils';
+import { useDatesContext } from '../DatesProvider';
 
 export type MonthPickerStylesNames = DecadeLevelGroupStylesNames | YearLevelGroupStylesNames;
 
@@ -79,6 +81,7 @@ export const MonthPicker: MonthPickerComponent = factory<MonthPickerFactory>((_p
     onMouseLeave,
     onMonthSelect,
     __updateDateOnMonthSelect,
+    __timezoneApplied,
     ...others
   } = props;
 
@@ -91,6 +94,7 @@ export const MonthPicker: MonthPickerComponent = factory<MonthPickerFactory>((_p
     defaultValue,
     onChange,
     onMouseLeave,
+    applyTimezone: !__timezoneApplied,
   });
 
   const { resolvedClassNames, resolvedStyles } = useResolvedStylesApi<MonthPickerFactory>({
@@ -98,6 +102,7 @@ export const MonthPicker: MonthPickerComponent = factory<MonthPickerFactory>((_p
     styles,
     props,
   });
+  const ctx = useDatesContext();
 
   return (
     <Calendar
@@ -118,6 +123,7 @@ export const MonthPicker: MonthPickerComponent = factory<MonthPickerFactory>((_p
       classNames={resolvedClassNames}
       styles={resolvedStyles}
       {...others}
+      date={shiftTimezone('add', others.date, ctx.getTimezone(), __timezoneApplied)}
     />
   );
 }) as any;

--- a/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.test.tsx
+++ b/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { tests, inputDefaultProps, inputStylesApiSelectors, render } from '@mantine/tests';
+import {
+  tests,
+  inputDefaultProps,
+  inputStylesApiSelectors,
+  render,
+  userEvent,
+} from '@mantine/tests';
 import { __InputStylesNames } from '@mantine/core';
-import { datesTests, expectValue } from '@mantine/dates-tests';
+import { clickInput, datesTests, expectValue } from '@mantine/dates-tests';
 import { MonthPickerInput, MonthPickerInputProps } from './MonthPickerInput';
+import { DatesProvider } from '../DatesProvider';
 
 const defaultProps = {
   popoverProps: { withinPortal: false, transitionProps: { duration: 0 } },
@@ -106,5 +113,25 @@ describe('@mantine/dates/MonthPickerInput', () => {
     expect(container.querySelector('table button')).toHaveClass(
       'mantine-MonthPickerInput-monthsListControl'
     );
+  });
+
+  it('can be controlled (type="default") with timezone', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <MonthPickerInput
+          {...defaultProps}
+          date={new Date(2022, 0, 31, 23)}
+          value={new Date(2022, 0, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    await clickInput(container);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('Feb');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2021, 11, 31, 19));
   });
 });

--- a/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.tsx
+++ b/src/mantine-dates/src/components/MonthPickerInput/MonthPickerInput.tsx
@@ -14,8 +14,9 @@ import { pickCalendarProps } from '../Calendar';
 import { useDatesInput } from '../../hooks';
 import { MonthPicker, MonthPickerBaseProps, MonthPickerStylesNames } from '../MonthPicker';
 import { DatePickerType } from '../../types';
-import { getDefaultClampedDate } from '../../utils';
+import { getDefaultClampedDate, shiftTimezone } from '../../utils';
 import { PickerInputBase, DateInputSharedProps } from '../PickerInputBase';
+import { useDatesContext } from '../DatesProvider';
 
 export type MonthPickerInputStylesNames = __InputStylesNames | MonthPickerStylesNames;
 
@@ -102,6 +103,7 @@ export const MonthPickerInput: MonthPickerInputComponent = factory<MonthPickerIn
       closeOnChange,
       sortDates,
     });
+    const ctx = useDatesContext();
 
     return (
       <PickerInputBase
@@ -124,6 +126,7 @@ export const MonthPickerInput: MonthPickerInputComponent = factory<MonthPickerIn
       >
         <MonthPicker
           {...calendarProps}
+          date={shiftTimezone('add', calendarProps.date, ctx.getTimezone())}
           size={size}
           variant={variant}
           type={type}
@@ -142,6 +145,7 @@ export const MonthPickerInput: MonthPickerInputComponent = factory<MonthPickerIn
           __stopPropagation={dropdownType === 'popover'}
           minDate={minDate}
           maxDate={maxDate}
+          __timezoneApplied
         />
       </PickerInputBase>
     );

--- a/src/mantine-dates/src/components/YearPicker/YearPicker.test.tsx
+++ b/src/mantine-dates/src/components/YearPicker/YearPicker.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, tests, userEvent, screen } from '@mantine/tests';
 import { datesTests } from '@mantine/dates-tests';
 import { YearPicker, YearPickerProps, YearPickerStylesNames } from './YearPicker';
+import { DatesProvider } from '../DatesProvider';
 
 const defaultProps = {};
 
@@ -44,6 +45,28 @@ describe('@mantine/dates/YearPicker', () => {
     expect(container.querySelector('[data-selected]')!.textContent).toBe('2020');
   });
 
+  it('can be uncontrolled (type="default") with timezone (UTC)', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <YearPicker {...defaultProps} date={new Date(2019, 11, 31, 23)} />
+      </DatesProvider>
+    );
+    expect(container.querySelector('[data-selected]')).toBe(null);
+    await userEvent.click(container.querySelector('table button')!);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2020');
+  });
+
+  it('can be uncontrolled (type="default") with timezone (America/Los_Angeles)', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'America/Los_Angeles' }}>
+        <YearPicker {...defaultProps} date={new Date(2020, 11, 31, 23)} />
+      </DatesProvider>
+    );
+    expect(container.querySelector('[data-selected]')).toBe(null);
+    await userEvent.click(container.querySelector('table button')!);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2020');
+  });
+
   it('can be controlled (type="default")', async () => {
     const spy = jest.fn();
     const { container } = render(
@@ -61,9 +84,83 @@ describe('@mantine/dates/YearPicker', () => {
     expect(spy).toHaveBeenCalledWith(new Date(2020, 0, 1));
   });
 
+  it('can be controlled (type="default") with timezone (UTC)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <YearPicker
+          {...defaultProps}
+          date={new Date(2019, 11, 31, 23)}
+          value={new Date(2022, 11, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2023');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2019, 11, 31, 19));
+  });
+
+  it('can be controlled (type="default") with timezone (America/Los_Angeles)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'America/Los_Angeles' }}>
+        <YearPicker
+          {...defaultProps}
+          date={new Date(2020, 10, 31, 23)}
+          value={new Date(2022, 11, 31, 23)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2022');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2020, 0, 1, 3));
+  });
+
   it('can be uncontrolled (type="multiple")', async () => {
     const { container } = render(
       <YearPicker {...defaultProps} type="multiple" date={new Date(2022, 3, 11)} />
+    );
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(0);
+    await userEvent.click(container.querySelectorAll('table button')[0]);
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(1);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2020');
+
+    await userEvent.click(container.querySelectorAll('table button')[1]);
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(2);
+    expect(
+      Array.from(container.querySelectorAll('[data-selected]')).map((node) => node.textContent)
+    ).toStrictEqual(['2020', '2021']);
+  });
+
+  it('can be uncontrolled (type="multiple") with timezone (UTC)', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <YearPicker {...defaultProps} type="multiple" date={new Date(2022, 3, 11)} />
+      </DatesProvider>
+    );
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(0);
+    await userEvent.click(container.querySelectorAll('table button')[0]);
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(1);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2020');
+
+    await userEvent.click(container.querySelectorAll('table button')[1]);
+    expect(container.querySelectorAll('[data-selected]')).toHaveLength(2);
+    expect(
+      Array.from(container.querySelectorAll('[data-selected]')).map((node) => node.textContent)
+    ).toStrictEqual(['2020', '2021']);
+  });
+
+  it('can be uncontrolled (type="multiple") with timezone (America/Los_Angeles)', async () => {
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'America/Los_Angeles' }}>
+        <YearPicker {...defaultProps} type="multiple" date={new Date(2022, 3, 11)} />
+      </DatesProvider>
     );
     expect(container.querySelectorAll('[data-selected]')).toHaveLength(0);
     await userEvent.click(container.querySelectorAll('table button')[0]);
@@ -91,6 +188,42 @@ describe('@mantine/dates/YearPicker', () => {
 
     await userEvent.click(container.querySelector('table button')!);
     expect(spy).toHaveBeenCalledWith([new Date(2023, 3, 11), new Date(2020, 0, 1)]);
+  });
+
+  it('can be controlled (type="multiple") with timezone (UTC)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <YearPicker
+          {...defaultProps}
+          type="multiple"
+          date={new Date(2022, 3, 11)}
+          value={[new Date(2023, 3, 11)]}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith([new Date(2023, 3, 11), new Date(2019, 11, 31, 19)]);
+  });
+
+  it('can be controlled (type="multiple") with timezone (America/Los_Angeles)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'America/Los_Angeles' }}>
+        <YearPicker
+          {...defaultProps}
+          type="multiple"
+          date={new Date(2022, 3, 11)}
+          value={[new Date(2023, 3, 11)]}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith([new Date(2023, 3, 11), new Date(2020, 0, 1, 3)]);
   });
 
   it('can be uncontrolled (type="range")', async () => {

--- a/src/mantine-dates/src/components/YearPicker/YearPicker.tsx
+++ b/src/mantine-dates/src/components/YearPicker/YearPicker.tsx
@@ -14,6 +14,8 @@ import { DecadeLevelBaseSettings } from '../DecadeLevel';
 import { PickerBaseProps, DatePickerType } from '../../types';
 import { Calendar, CalendarBaseProps } from '../Calendar';
 import { DecadeLevelGroupStylesNames } from '../DecadeLevelGroup';
+import { shiftTimezone } from '../../utils';
+import { useDatesContext } from '../DatesProvider';
 
 export type YearPickerStylesNames = DecadeLevelGroupStylesNames;
 
@@ -62,6 +64,7 @@ export const YearPicker: YearPickerComponent = factory<YearPickerFactory>((_prop
     onMouseLeave,
     onYearSelect,
     __updateDateOnYearSelect,
+    __timezoneApplied,
     ...others
   } = props;
 
@@ -74,6 +77,7 @@ export const YearPicker: YearPickerComponent = factory<YearPickerFactory>((_prop
     defaultValue,
     onChange,
     onMouseLeave,
+    applyTimezone: !__timezoneApplied,
   });
 
   const { resolvedClassNames, resolvedStyles } = useResolvedStylesApi<YearPickerFactory>({
@@ -81,6 +85,7 @@ export const YearPicker: YearPickerComponent = factory<YearPickerFactory>((_prop
     styles,
     props,
   });
+  const ctx = useDatesContext();
 
   return (
     <Calendar
@@ -101,6 +106,8 @@ export const YearPicker: YearPickerComponent = factory<YearPickerFactory>((_prop
       classNames={resolvedClassNames}
       styles={resolvedStyles}
       {...others}
+      date={shiftTimezone('add', others.date, ctx.getTimezone(), __timezoneApplied)}
+      __timezoneApplied
     />
   );
 }) as any;

--- a/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.test.tsx
+++ b/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { tests, inputDefaultProps, inputStylesApiSelectors, render } from '@mantine/tests';
+import {
+  tests,
+  inputDefaultProps,
+  inputStylesApiSelectors,
+  render,
+  userEvent,
+} from '@mantine/tests';
 import { __InputStylesNames } from '@mantine/core';
-import { datesTests, expectValue } from '@mantine/dates-tests';
+import { clickInput, datesTests, expectValue } from '@mantine/dates-tests';
 import { YearPickerInput, YearPickerInputProps } from './YearPickerInput';
+import { DatesProvider } from '../DatesProvider';
 
 const defaultProps = {
   popoverProps: { withinPortal: false, transitionProps: { duration: 0 } },
@@ -96,5 +103,45 @@ describe('@mantine/dates/YearPickerInput', () => {
     expect(container.querySelector('table button')).toHaveClass(
       'mantine-YearPickerInput-yearsListControl'
     );
+  });
+
+  it('can be controlled (type="default") with timezone (UTC)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'UTC' }}>
+        <YearPickerInput
+          {...defaultProps}
+          date={new Date(2022, 3, 11)}
+          value={new Date(2023, 3, 11)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    await clickInput(container);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2023');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2019, 11, 31, 19));
+  });
+
+  it('can be controlled (type="default") with timezone (America/Los_Angeles)', async () => {
+    const spy = jest.fn();
+    const { container } = render(
+      <DatesProvider settings={{ timezone: 'America/Los_Angeles' }}>
+        <YearPickerInput
+          {...defaultProps}
+          date={new Date(2022, 3, 11)}
+          value={new Date(2023, 3, 11)}
+          onChange={spy}
+        />
+      </DatesProvider>
+    );
+
+    await clickInput(container);
+    expect(container.querySelector('[data-selected]')!.textContent).toBe('2023');
+
+    await userEvent.click(container.querySelector('table button')!);
+    expect(spy).toHaveBeenCalledWith(new Date(2020, 0, 1, 3));
   });
 });

--- a/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.tsx
+++ b/src/mantine-dates/src/components/YearPickerInput/YearPickerInput.tsx
@@ -14,8 +14,9 @@ import { pickCalendarProps } from '../Calendar';
 import { useDatesInput } from '../../hooks';
 import { YearPicker, YearPickerBaseProps, YearPickerStylesNames } from '../YearPicker';
 import { DatePickerType } from '../../types';
-import { getDefaultClampedDate } from '../../utils';
+import { getDefaultClampedDate, shiftTimezone } from '../../utils';
 import { PickerInputBase, DateInputSharedProps } from '../PickerInputBase';
+import { useDatesContext } from '../DatesProvider';
 
 export type YearPickerInputStylesNames = __InputStylesNames | YearPickerStylesNames;
 
@@ -82,6 +83,7 @@ export const YearPickerInput: YearPickerInputComponent = factory<YearPickerInput
     });
 
     const { calendarProps, others } = pickCalendarProps(rest);
+    const ctx = useDatesContext();
 
     const {
       _value,
@@ -130,8 +132,9 @@ export const YearPickerInput: YearPickerInputComponent = factory<YearPickerInput
           value={_value}
           defaultDate={
             Array.isArray(_value)
-              ? _value[0] || getDefaultClampedDate({ maxDate, minDate })
-              : _value || getDefaultClampedDate({ maxDate, minDate })
+              ? _value[0] ||
+                getDefaultClampedDate({ maxDate, minDate, timezone: ctx.getTimezone() })
+              : _value || getDefaultClampedDate({ maxDate, minDate, timezone: ctx.getTimezone() })
           }
           onChange={setValue}
           locale={locale}
@@ -142,6 +145,8 @@ export const YearPickerInput: YearPickerInputComponent = factory<YearPickerInput
           __stopPropagation={dropdownType === 'popover'}
           minDate={minDate}
           maxDate={maxDate}
+          date={shiftTimezone('add', calendarProps.date, ctx.getTimezone())}
+          __timezoneApplied
         />
       </PickerInputBase>
     );

--- a/src/mantine-dates/src/hooks/use-dates-state/use-dates-state.ts
+++ b/src/mantine-dates/src/hooks/use-dates-state/use-dates-state.ts
@@ -9,6 +9,7 @@ interface UseDatesRangeInput<Type extends DatePickerType = 'default'>
   level: 'year' | 'month' | 'day';
   type: Type;
   onMouseLeave?(event: React.MouseEvent<HTMLDivElement>): void;
+  applyTimezone?: boolean;
 }
 
 export function useDatesState<Type extends DatePickerType = 'default'>({
@@ -20,8 +21,15 @@ export function useDatesState<Type extends DatePickerType = 'default'>({
   allowSingleDateInRange,
   allowDeselect,
   onMouseLeave,
+  applyTimezone = true,
 }: UseDatesRangeInput<Type>) {
-  const [_value, setValue] = useUncontrolledDates({ type, value, defaultValue, onChange });
+  const [_value, setValue] = useUncontrolledDates({
+    type,
+    value,
+    defaultValue,
+    onChange,
+    applyTimezone,
+  });
 
   const [pickedDate, setPickedDate] = useState<Date | null>(
     type === 'range' ? (_value[0] && !_value[1] ? _value[0] : null) : null

--- a/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.ts
+++ b/src/mantine-dates/src/hooks/use-uncontrolled-dates/use-uncontrolled-dates.ts
@@ -1,12 +1,15 @@
 import { useUncontrolled } from '@mantine/hooks';
 import { useRef } from 'react';
 import { DatePickerType, DatePickerValue } from '../../types';
+import { shiftTimezone } from '../../utils';
+import { useDatesContext } from '../../components/DatesProvider';
 
 interface UseUncontrolledDates<Type extends DatePickerType = 'default'> {
   type: Type;
   value: DatePickerValue<Type> | undefined;
   defaultValue: DatePickerValue<Type> | undefined;
   onChange: ((value: DatePickerValue<Type>) => void) | undefined;
+  applyTimezone?: boolean;
 }
 
 const getEmptyValue = <Type extends DatePickerType = 'default'>(type: Type) =>
@@ -17,13 +20,17 @@ export function useUncontrolledDates<Type extends DatePickerType = 'default'>({
   value,
   defaultValue,
   onChange,
+  applyTimezone = true,
 }: UseUncontrolledDates<Type>) {
   const storedType = useRef<Type>(type);
-  const [_value, _setValue] = useUncontrolled<any>({
-    value,
-    defaultValue,
-    onChange,
+  const ctx = useDatesContext();
+  const [_value, _setValue, controlled] = useUncontrolled<any>({
+    value: shiftTimezone('add', value, ctx.getTimezone(), !applyTimezone),
+    defaultValue: shiftTimezone('add', defaultValue, ctx.getTimezone(), !applyTimezone),
     finalValue: getEmptyValue(type),
+    onChange: (newDate) => {
+      onChange?.(shiftTimezone('remove', newDate, ctx.getTimezone(), !applyTimezone));
+    },
   });
 
   let _finalValue = _value;
@@ -67,5 +74,5 @@ export function useUncontrolledDates<Type extends DatePickerType = 'default'>({
     }
   }
 
-  return [_finalValue, _setValue];
+  return [_finalValue, _setValue, controlled];
 }

--- a/src/mantine-dates/src/utils/get-default-clamped-date.ts
+++ b/src/mantine-dates/src/utils/get-default-clamped-date.ts
@@ -1,12 +1,14 @@
 import dayjs from 'dayjs';
+import { shiftTimezone } from './shift-timezone';
 
 interface GetDefaultClampedDate {
   minDate: Date | undefined;
   maxDate: Date | undefined;
+  timezone?: string;
 }
 
-export function getDefaultClampedDate({ minDate, maxDate }: GetDefaultClampedDate) {
-  const today = new Date();
+export function getDefaultClampedDate({ minDate, maxDate, timezone }: GetDefaultClampedDate) {
+  const today = shiftTimezone('add', new Date(), timezone);
 
   if (!minDate && !maxDate) {
     return today;

--- a/src/mantine-dates/src/utils/get-timezone-offset.test.ts
+++ b/src/mantine-dates/src/utils/get-timezone-offset.test.ts
@@ -1,0 +1,16 @@
+import { getTimezoneOffset } from './get-timezone-offset';
+
+const testDate = new Date(2022, 3, 11, 20, 45, 13);
+
+describe('@mantine/dates/get-timezone-offset', () => {
+  it('test environment timezone should be "America/New_York"', () => {
+    expect(new Date().getTimezoneOffset()).toBe(240);
+  });
+
+  it('should return correct timezone offset', () => {
+    expect(getTimezoneOffset(testDate, 'UTC')).toEqual(240);
+    expect(getTimezoneOffset(testDate, 'America/New_York')).toEqual(0);
+    expect(getTimezoneOffset(testDate, 'America/Los_Angeles')).toEqual(-180);
+    expect(getTimezoneOffset(testDate, 'Europe/Vienna')).toEqual(360);
+  });
+});

--- a/src/mantine-dates/src/utils/get-timezone-offset.ts
+++ b/src/mantine-dates/src/utils/get-timezone-offset.ts
@@ -1,0 +1,13 @@
+import dayjs from 'dayjs';
+import utcPlugin from 'dayjs/plugin/utc';
+import timezonePlugin from 'dayjs/plugin/timezone';
+
+dayjs.extend(utcPlugin);
+dayjs.extend(timezonePlugin);
+
+export function getTimezoneOffset(date: Date, timezone?: string) {
+  if (timezone) {
+    return dayjs(date).tz(timezone).utcOffset() + date.getTimezoneOffset();
+  }
+  return 0;
+}

--- a/src/mantine-dates/src/utils/index.ts
+++ b/src/mantine-dates/src/utils/index.ts
@@ -2,3 +2,4 @@ export { getFormattedDate } from './get-formatted-date';
 export { handleControlKeyDown } from './handle-control-key-down';
 export { assignTime } from './assign-time/assign-time';
 export { getDefaultClampedDate } from './get-default-clamped-date';
+export { shiftTimezone } from './shift-timezone';

--- a/src/mantine-dates/src/utils/shift-timezone.ts
+++ b/src/mantine-dates/src/utils/shift-timezone.ts
@@ -1,0 +1,38 @@
+import dayjs from 'dayjs';
+import { getTimezoneOffset } from './get-timezone-offset';
+import { DatesRangeValue, DateValue } from '../types';
+
+type TimeShiftDirection = 'add' | 'remove';
+
+const updateTimezone = (
+  date: DateValue | undefined,
+  timezone?: string,
+  direction?: TimeShiftDirection
+): DateValue => {
+  if (!date) {
+    return null;
+  }
+  if (!timezone) {
+    return date;
+  }
+  let offset = getTimezoneOffset(date, timezone);
+  if (direction === 'remove') {
+    offset *= -1;
+  }
+  return dayjs(date).add(offset, 'minutes').toDate();
+};
+
+export function shiftTimezone<T extends DateValue | Date[] | DatesRangeValue | undefined>(
+  direction: TimeShiftDirection,
+  date: T,
+  timezone?: string,
+  disabled?: boolean
+): T {
+  if (disabled || !date) {
+    return date;
+  }
+  if (Array.isArray(date)) {
+    return date.map((d) => updateTimezone(d, timezone, direction)) as T;
+  }
+  return updateTimezone(date, timezone, direction) as T;
+}

--- a/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.timezone.tsx
+++ b/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.timezone.tsx
@@ -17,7 +17,11 @@ function Demo() {
 function Demo() {
   return (
     <DatesProvider settings={{ timezone: 'America/New_York' }}>
-      <DateTimePicker label="Pick a Date" placeholder="Pick a Date" defaultValue={new Date('2000-10-03 02:10:00Z')} />
+      <DateTimePicker
+        label="Pick a Date"
+        placeholder="Pick a Date"
+        defaultValue={new Date('2000-10-03 02:10:00Z')}
+      />
     </DatesProvider>
   );
 }

--- a/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.timezone.tsx
+++ b/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.timezone.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MantineDemo } from '@mantine/ds';
+import { DatesProvider, DateTimePicker } from '@mantine/dates';
+
+const code = `
+import { DatesProvider, DateTimePicker } from '@mantine/dates';
+
+function Demo() {
+  return (
+    <DatesProvider settings={{ timezone: 'America/New_York' }}>
+      <DateTimePicker label="Pick a Date" placeholder="Pick a Date" defaultValue={new Date('2000-10-03 02:10:00Z')} />
+    </DatesProvider>
+  );
+}
+`;
+
+function Demo() {
+  return (
+    <DatesProvider settings={{ timezone: 'America/New_York' }}>
+      <DateTimePicker label="Pick a Date" placeholder="Pick a Date" defaultValue={new Date('2000-10-03 02:10:00Z')} />
+    </DatesProvider>
+  );
+}
+
+export const timezone: MantineDemo = {
+  type: 'code',
+  component: Demo,
+  code,
+};

--- a/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.usage.tsx
@@ -9,7 +9,7 @@ import { DatesProvider, MonthPickerInput, DatePickerInput } from '@mantine/dates
 
 function Demo() {
   return (
-    <DatesProvider settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [0] }}>
+    <DatesProvider settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [0], timezone: 'UTC' }}>
       <MonthPickerInput label="Pick month" placeholder="Pick month" />
       <DatePickerInput mt="md" label="Pick date" placeholder="Pick date" />
     </DatesProvider>
@@ -19,7 +19,7 @@ function Demo() {
 
 function Demo() {
   return (
-    <DatesProvider settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [0] }}>
+    <DatesProvider settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [0], timezone: 'UTC' }}>
       <MonthPickerInput label="Pick month" placeholder="Pick month" />
       <DatePickerInput mt="md" label="Pick date" placeholder="Pick date" />
     </DatesProvider>

--- a/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/dates/DatesProvider/DatesProvider.demo.usage.tsx
@@ -19,7 +19,9 @@ function Demo() {
 
 function Demo() {
   return (
-    <DatesProvider settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [0], timezone: 'UTC' }}>
+    <DatesProvider
+      settings={{ locale: 'ru', firstDayOfWeek: 0, weekendDays: [0], timezone: 'UTC' }}
+    >
       <MonthPickerInput label="Pick month" placeholder="Pick month" />
       <DatePickerInput mt="md" label="Pick date" placeholder="Pick date" />
     </DatesProvider>

--- a/src/mantine-demos/src/demos/dates/DatesProvider/index.ts
+++ b/src/mantine-demos/src/demos/dates/DatesProvider/index.ts
@@ -1,1 +1,2 @@
 export { usage } from './DatesProvider.demo.usage';
+export { timezone } from './DatesProvider.demo.timezone';


### PR DESCRIPTION
Addresses https://github.com/mantinedev/mantine/issues/3432

I added a timezone setting to the `DatesProvider`, allowing to shift the dates for the components using it. Dates are shifted back and forth by the parent component. It is also used in some helper functions as needed.

It is a bit hacky but the only possible solution to not introduce breaking changes.